### PR TITLE
fix: Correct Typographical Errors in Documentation

### DIFF
--- a/sui/cetus_clmm/README.md
+++ b/sui/cetus_clmm/README.md
@@ -115,7 +115,7 @@ struct Pool<phantom CoinTypeA, phantom CoinTypeB> has key, store {
     fee_growth_global_a: u128,
     fee_growth_global_b: u128,
 
-    /// The amounts of coin a,b owend to protocol
+    /// The amounts of coin a,b owned to protocol
     fee_protocol_coin_a: u64,
     fee_protocol_coin_b: u64,
 

--- a/sui/dca/README.md
+++ b/sui/dca/README.md
@@ -2,7 +2,7 @@
 
 ## What is Cetus DCA ?
 
-Cetus DAC(Dollar Cost Averaging) can help users achieve the goal of purchasing a specific token at fixed intervals with a fixed amount, regardless of how the market price fluctuates.
+Cetus DCA(Dollar Cost Averaging) can help users achieve the goal of purchasing a specific token at fixed intervals with a fixed amount, regardless of how the market price fluctuates.
 
 ## What is Cetus DCA Interface ?
 
@@ -35,7 +35,7 @@ CetusDCA = { git = "https://github.com/CetusProtocol/cetus-clmm-interface.git", 
 
 ## Usage
 
-Cetus DCA interface is not complete(just have function defination), so it will fails when sui clien check the code version. However, this does not affect its actual functionality. Therefore, we need to add a `--dependencies-are-root` during the build.
+Cetus DCA interface is not complete(just have function definition), so it will fails when sui client check the code version. However, this does not affect its actual functionality. Therefore, we need to add a `--dependencies-are-root` during the build.
 
 ```bash
 sui move build --dependencies-are-root && sui client publish --dependencies-are-root

--- a/sui/limitorder/README.md
+++ b/sui/limitorder/README.md
@@ -35,7 +35,7 @@ LimitOrder = { git = "https://github.com/CetusProtocol/cetus-clmm-interface.git"
 
 ## Usage
 
-Cetus limitorder interface is not complete(just have function defination), so it will fails when sui clien check the code version. However, this does not affect its actual functionality. Therefore, we need to add a `--dependencies-are-root` during the build.
+Cetus limitorder interface is not complete(just have function definition), so it will fails when sui client check the code version. However, this does not affect its actual functionality. Therefore, we need to add a `--dependencies-are-root` during the build.
 
 ```bash
 sui move build --dependencies-are-root && sui client publish --dependencies-are-root
@@ -184,11 +184,11 @@ Users can quickly find orders created by a specific owner through the order inde
 2. rate calculation formula
 
    ```
-   percision = 10 ^ 18
+   precision = 10 ^ 18
    ```
 
    ```
-   rate = (pay amount * percision) / target amount
+   rate = (pay amount * precision) / target amount
    ```
 
 3. explanation of the formula:

--- a/sui/lp_burn/README.md
+++ b/sui/lp_burn/README.md
@@ -73,7 +73,7 @@ LpBurn = { git = "https://github.com/CetusProtocol/cetus-clmm-interface.git", su
    ```
 
 2. Burn.
-   The entry function to burn positon, it will auto transfer `CetusLPBurnProof` to tx sender.
+   The entry function to burn position, it will auto transfer `CetusLPBurnProof` to tx sender.
 
    ```move
    public entry fun burn<A,B>(

--- a/sui/token/README.md
+++ b/sui/token/README.md
@@ -8,7 +8,7 @@ CETUS is the main token of the Cetus Protocol, while xCETUS is the Cetus escrowe
 
 Details: https://cetus-1.gitbook.io/cetus-docs/tokenomics/cetus
 
-Dividends is the protocol to manage bonus about xcetus. User can use reedeem_v2 to collect multi bonus.
+Dividends is the protocol to manage bonus about xcetus. User can use redeem_v2 to collect multi bonus.
 
 ### VeNFT
 


### PR DESCRIPTION
This pull request fixes several typographical errors in the README files across different modules of the Cetus Protocol repository. These changes correct spelling mistakes and improve clarity. Below is a summary of the adjustments made based on the screenshots provided:

### Summary of Changes:
1. **sui/cetus_clmm/README.md**
   - Corrected "owend" to "owned" in the comment about protocol fees.

2. **sui/dca/README.md**
   - Changed "DAC" to "DCA" in the introductory paragraph for accurate terminology.
   - Fixed spelling of "defination" to "definition".
   - Corrected "clien" to "client" in the Usage section.

3. **sui/limitorder/README.md**
   - Fixed spelling of "defination" to "definition".
   - Corrected "clien" to "client" for accuracy.
   - Replaced "percision" with "precision" in the rate calculation formula.

4. **sui/lp_burn/README.md**
   - Corrected "positon" to "position" in the burn function description.

5. **sui/token/README.md**
   - Fixed "reedeem_v2" to "redeem_v2" in the Dividends section.

---

**Comments for Maintainers:**
- All corrections are minimal and aimed solely at fixing typographical errors without altering the original meaning.
- Let me know if further clarification is needed.

Thank you for reviewing this pull request!
