### PR TITLE
Fix typos in comments and documentation

### DIFF
--- a/sui/stable_farming/sources/acl.move
+++ b/sui/stable_farming/sources/acl.move
@@ -62,7 +62,7 @@ module stable_farming::acl {
         abort 0
     }
 
-    /// Get the permission of member by addresss.
+    /// Get the permission of member by address.
     public fun get_permission(_acl: &ACL, _address: address): u128 {
         abort 0
     }

--- a/sui/token/xcetus/sources/lock_coin.move
+++ b/sui/token/xcetus/sources/lock_coin.move
@@ -1,5 +1,5 @@
 #[allow(unused_type_parameter, unused_field)]
-// This module is used for locking coin in `LockedCoin` object which cannot be transfered.
+// This module is used for locking coin in `LockedCoin` object which cannot be transferred.
 // When the lock time ends, the user can unwrap the `Balance` from `LockedCoin`.
 module xcetus::lock_coin {
     use std::type_name::TypeName;

--- a/sui/token/xcetus/sources/locking.move
+++ b/sui/token/xcetus/sources/locking.move
@@ -132,7 +132,7 @@ module xcetus::locking {
 
 
     /// Cancel the redeem lock.
-    /// The CETUS will be send back to LockManger, LockedCoin will be destoryed. the state related to xCETUS will be updated.
+    /// The CETUS will be send back to LockManger, LockedCoin will be destroyed. the state related to xCETUS will be updated.
     public fun cancel_redeem_lock(
         _: &mut LockUpManager,
         _: &mut XcetusManager,

--- a/sui/token/xcetus/sources/xcetus.move
+++ b/sui/token/xcetus/sources/xcetus.move
@@ -2,7 +2,7 @@
 // This module is about:
 // create the xcetus coin,
 // provide the management of `VeNFT`,
-// store the informations about VeNFTs, and the update of these states of venfts.
+// store the information about VeNFTs, and the update of these states of venfts.
 // The VenftInfo list info is used for supporting the activities of higher level contracts.
 // This module work with `locking` module.
 // A `AdminCap` exists in this module, which can mint, burn xcetus in some situations.


### PR DESCRIPTION


This pull request fixes several typos in code comments and documentation:

- In `acl.move`: Fixed "addresss" to "address"
- In `lock_coin.move`: Fixed "transfered" to "transferred"
- In `locking.move`: Fixed "destoryed" to "destroyed"
- In `xcetus.move`: Fixed "informations" to "information"

These changes only affect comments and do not modify any functional code.
